### PR TITLE
Convert miniflux logo green to catppuccin green

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+package.json
+package-lock.json
+node_modules/

--- a/styles/frappe.css
+++ b/styles/frappe.css
@@ -19,6 +19,10 @@
   --rosewater: #f2d5cf;
 }
 
+.logo a span {
+  color: var(--green);
+}
+
 .alert-error {
   color: var(--body-background);
 }

--- a/styles/latte.css
+++ b/styles/latte.css
@@ -20,6 +20,10 @@
   --rosewater: #dc8a78;
 }
 
+.logo a span {
+  color: var(--green);
+}
+
 .alert-error {
   color: var(--body-background);
 }

--- a/styles/macchiato.css
+++ b/styles/macchiato.css
@@ -19,6 +19,10 @@
   --rosewater: #f4dbd6;
 }
 
+.logo a span {
+  color: var(--green);
+}
+
 .alert-error {
   color: var(--body-background);
 }

--- a/styles/mocha.css
+++ b/styles/mocha.css
@@ -20,6 +20,10 @@
   --rosewater: #f5e0dc;
 }
 
+.logo a span {
+  color: var(--green);
+}
+
 .alert-error {
   color: var(--body-background);
 }


### PR DESCRIPTION
Adds theming for the miniflux logo. Use prettier for formatting, but ignore all related npm files through `.gitignore`