### PR TITLE
refactor: use whiskers to generate themes

### DIFF
--- a/.github/workflows/whiskers-check.yml
+++ b/.github/workflows/whiskers-check.yml
@@ -1,0 +1,15 @@
+name: whiskers
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  run:
+    uses: catppuccin/actions/.github/workflows/whiskers-check.yml@v1
+    with:
+      args: miniflux.tera
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@
 
 ## Usage
 
-1. In minifux, go to Settings > Custom CSS
-2. Paste the style of your choice into the text box at the bottom of the page.
-3. Click save
+1. Copy your preferred flavour from the [themes](./themes) directory.
+2. In miniflux, go to Settings > Custom CSS
+3. Paste the CSS into the text box at the bottom of the page.
+4. Click save.
 
 ## 💝 Thanks to
 

--- a/miniflux.tera
+++ b/miniflux.tera
@@ -6,7 +6,7 @@ whiskers:
   filename: "themes/catppuccin-{{ flavor.identifier }}.css"
   hex_format: "#{{r}}{{g}}{{b}}{{z}}"
 ---
-:root: {
+:root {
 {%- for _, color in flavor.colors %}
   --{{ color.identifier }}: {{ color.hex }};
 {%- endfor %}

--- a/miniflux.tera
+++ b/miniflux.tera
@@ -6,7 +6,7 @@ whiskers:
   filename: "themes/catppuccin-{{ flavor.identifier }}.css"
   hex_format: "#{{r}}{{g}}{{b}}{{z}}"
 ---
-root: {
+:root: {
 {%- for _, color in flavor.colors %}
   --{{ color.identifier }}: {{ color.hex }};
 {%- endfor %}

--- a/miniflux.tera
+++ b/miniflux.tera
@@ -1,22 +1,15 @@
-:root {
-  --base: #303446;
-  --surface0: #414559;
-  --surface1: #51576d;
-  --surface2: #626880;
-  --overlay0: #737994;
-  --overlay1: #838ba7;
-  --overlay2: #949cbb;
-  --subtext0: #a5adce;
-  --text: #c6d0f5;
-  --yellow: #e5c890;
-  --peach: #ef9f76;
-  --red: #e78284;
-  --pink: #f4b8e4;
-  --mauve: #ca9ee6;
-  --blue: #8caaee;
-  --sky: #99d1db;
-  --green: #a6d189;
-  --rosewater: #f2d5cf;
+---
+whiskers:
+  version: ^2.5.1
+  matrix:
+    - flavor
+  filename: "themes/catppuccin-{{ flavor.identifier }}.css"
+  hex_format: "#{{r}}{{g}}{{b}}{{z}}"
+---
+root: {
+{%- for _, color in flavor.colors %}
+  --{{ color.identifier }}: {{ color.hex }};
+{%- endfor %}
 }
 
 .logo a span {

--- a/themes/catppuccin-frappe.css
+++ b/themes/catppuccin-frappe.css
@@ -1,4 +1,4 @@
-:root: {
+:root {
   --rosewater: #f2d5cf;
   --flamingo: #eebebe;
   --pink: #f4b8e4;

--- a/themes/catppuccin-frappe.css
+++ b/themes/catppuccin-frappe.css
@@ -1,0 +1,215 @@
+root: {
+  --rosewater: #f2d5cf;
+  --flamingo: #eebebe;
+  --pink: #f4b8e4;
+  --mauve: #ca9ee6;
+  --red: #e78284;
+  --maroon: #ea999c;
+  --peach: #ef9f76;
+  --yellow: #e5c890;
+  --green: #a6d189;
+  --teal: #81c8be;
+  --sky: #99d1db;
+  --sapphire: #85c1dc;
+  --blue: #8caaee;
+  --lavender: #babbf1;
+  --text: #c6d0f5;
+  --subtext1: #b5bfe2;
+  --subtext0: #a5adce;
+  --overlay2: #949cbb;
+  --overlay1: #838ba7;
+  --overlay0: #737994;
+  --surface2: #626880;
+  --surface1: #51576d;
+  --surface0: #414559;
+  --base: #303446;
+  --mantle: #292c3c;
+  --crust: #232634;
+}
+
+.logo a span {
+  color: var(--green);
+}
+
+.alert-error {
+  color: var(--body-background);
+}
+
+.confirm {
+  color: var(--alert-confirm-color);
+}
+
+.confirm > button {
+  color: var(--alert-confirm-color);
+}
+
+.confirm > a {
+  color: var(--alert-confirm-color);
+}
+
+.confirm {
+  background-color: var(--alert-background-color);
+}
+
+.entry-meta > span > a {
+  color: var(--entry-meta-color);
+}
+
+.entry-date {
+  color: var(--entry-meta-color);
+}
+
+.entry header h1 a:hover,
+.entry header h1 a:focus {
+  color: --var(link-hover-color);
+}
+
+input[type="search"],
+input[type="url"],
+input[type="password"],
+input[type="text"],
+input[type="number"],
+select,
+textarea {
+  color: var(--input-color);
+  background: var(--input-background);
+  border: var(--input-border);
+}
+
+label input[type="checkbox"] {
+  accent-color: var(--button-primary);
+}
+
+.button.button-primary:hover,
+.button.button-primary:focus {
+  background-color: var(--button-primary-background);
+}
+.button.button-primary:disabled {
+  color: var(--button-primary-color);
+  border-color: var(--button-primary-focus-border-color);
+  background-color: var(--button-primary-focus-background);
+  opacity: 0.75;
+}
+
+.entry-content figcaption {
+  color: var(--entry-content-fig-caption);
+}
+
+.entry-author {
+  color: var(--entry-author-color);
+}
+
+.item-meta > ul > li {
+  color: var(--item-meta-li-color);
+}
+
+.item-meta > ul > li > a {
+  color: var(--item-meta-li-color);
+}
+
+.item-meta > ul > li > a:hover {
+  color: var(--item-meta-focus-color);
+}
+
+.item-meta-icons li > :is(a, button) {
+  color: var(--item-meta-li-color);
+}
+
+.item-meta-icons li > :is(a, button):hover {
+  color: var(--item-meta-focus-color);
+}
+
+:root {
+  --item-status-read-title-link-color: var(--link-color);
+  --body-color: var(--text);
+  --body-background: var(--base);
+  --hr-border-color: var(--overlay1);
+  --title-color: var(--text);
+  --link-color: var(--blue);
+  --link-focus-color: var(--surface1);
+  --link-hover-color: var(--lavender);
+  --link-visited-color: var(--mauve);
+  --header-list-border-color: var(--overlay1);
+  --header-link-color: var(--blue);
+  --header-link-focus-color: var(--key);
+  --header-link-hover-color: var(--lavender);
+  --header-active-link-color: var(--overlay1);
+  --table-border-color: var(--overlay1);
+  --table-th-background: var(--surface0);
+  --table-th-color: var(--overlay0);
+  --table-tr-hover-background-color: var(--base);
+  --table-tr-hover-color: var(--overlay0);
+  --button-primary-border-color: var(--overlay0);
+  --button-primary-background: var(--overlay0);
+  --button-primary-color: var(--base);
+  --button-primary-focus-border-color: var(--overlay1);
+  --button-primary-focus-background: var(--overlay1);
+  --input-background: var(--surface0);
+  --input-color: var(--text);
+  --input-placeholder-color: var(--subtext1);
+  --input-focus-color: var(--text);
+  --input-focus-border-color: var(--surface1);
+  --input-border: var(--surface1);
+  --input-focus-box-shadow: 0 0 0 2px var(--overlay1);
+  --alert-color: var(--yellow);
+  --alert-confirm-color: var(--red);
+  --alert-background-color: var(--base);
+  --alert-border-color: var(--overlay1);
+  --alert-success-color: var(--green);
+  --alert-success-background-color: var(--surface0);
+  --alert-success-border-color: var(--overlay1);
+  --alert-error-color: var(--red);
+  --alert-error-background-color: var(--red);
+  --alert-error-border-color: var(--red);
+  --alert-info-color: var(--overlay0);
+  --alert-info-background-color: var(--surface0);
+  --alert-info-border-color: var(--surface0);
+  --page-header-title-border-color: var(--overlay1);
+  --page-header-title-color: var(--text);
+  --logo-color: var(--text);
+  --logo-hover-color-span: var(--blue);
+  --panel-background: var(--base);
+  --panel-border-color: var(--overlay1);
+  --panel-color: var(--text);
+  --modal-background: var(--base);
+  --modal-color: var(--overlay0);
+  --modal-box-shadow: 2px 0 5px 0 var(--overlay1);
+  --pagination-link-color: var(--blue);
+  --pagination-border-color: var(--overlay1);
+  --category-color: var(--text);
+  --category-background-color: var(--surface0);
+  --category-border-color: var(--overlay1);
+  --category-link-color: var(--blue);
+  --category-link-hover-color: var(--lavender);
+  --item-header-color: var(--text);
+  --item-border-color: var(--overlay1);
+  --item-status-unread-title-link-color: var(--blue);
+  --item-status-read-title-link-color: var(--mauve);
+  --item-status-read-title-focus-color: var(--overlay1);
+  --item-meta-focus-color: var(--text);
+  --item-meta-icons-external-url: var(--subtext0);
+  --item-meta-li-color: var(--subtext0);
+  --item-meta-icons-star: var(--subtext0);
+  --current-item-border-color: var(--surface0);
+  --entry-header-border-color: var(--overlay1);
+  --entry-header-title-link-color: var(--text);
+  --entry-meta-color: var(--mauve);
+  --entry-author-color: var(--green);
+  --entry-content-color: var(--text);
+  --entry-content-code-color: var(--blue);
+  --entry-content-code-background: var(--base);
+  --entry-content-code-border-color: var(--overlay1);
+  --entry-content-fig-caption: var(--subtext0);
+  --entry-content-quote-color: var(--mauve);
+  --entry-content-abbr-border-color: var(--overlay1);
+  --entry-enclosure-border-color: var(--overlay1);
+  --parsing-error-color: var(--overlay1);
+  --feed-parsing-error-background-color: var(--surface0);
+  --feed-parsing-error-border-color: var(--red);
+  --feed-has-unread-background-color: var(--surface0);
+  --feed-has-unread-border-color: var(--text);
+  --category-has-unread-background-color: var(--surface0);
+  --category-has-unread-border-color: var(--sky);
+  --keyboard-shortcuts-li-color: var(--overlay0);
+  --counter-color: var(--overlay0);
+}

--- a/themes/catppuccin-frappe.css
+++ b/themes/catppuccin-frappe.css
@@ -1,4 +1,4 @@
-root: {
+:root: {
   --rosewater: #f2d5cf;
   --flamingo: #eebebe;
   --pink: #f4b8e4;

--- a/themes/catppuccin-latte.css
+++ b/themes/catppuccin-latte.css
@@ -1,23 +1,30 @@
-:root {
-  --base: #1e1e2e;
-  --surface0: #313244;
-  --surface1: #45475a;
-  --surface2: #585b70;
-  --overlay0: #6c7086;
-  --overlay1: #7f849c;
-  --overlay2: #9399b2;
-  --subtext0: #a6adc8;
-  --text: #cdd6f4;
-  --yellow: #f9e2af;
-  --peach: #fab387;
-  --red: #f38ba8;
-  --lavender: #b4befe;
-  --pink: #f5c2e7;
-  --mauve: #cba6f7;
-  --blue: #89b4fa;
-  --sky: #89dceb;
-  --green: #a6e3a1;
-  --rosewater: #f5e0dc;
+root: {
+  --rosewater: #dc8a78;
+  --flamingo: #dd7878;
+  --pink: #ea76cb;
+  --mauve: #8839ef;
+  --red: #d20f39;
+  --maroon: #e64553;
+  --peach: #fe640b;
+  --yellow: #df8e1d;
+  --green: #40a02b;
+  --teal: #179299;
+  --sky: #04a5e5;
+  --sapphire: #209fb5;
+  --blue: #1e66f5;
+  --lavender: #7287fd;
+  --text: #4c4f69;
+  --subtext1: #5c5f77;
+  --subtext0: #6c6f85;
+  --overlay2: #7c7f93;
+  --overlay1: #8c8fa1;
+  --overlay0: #9ca0b0;
+  --surface2: #acb0be;
+  --surface1: #bcc0cc;
+  --surface0: #ccd0da;
+  --base: #eff1f5;
+  --mantle: #e6e9ef;
+  --crust: #dce0e8;
 }
 
 .logo a span {

--- a/themes/catppuccin-latte.css
+++ b/themes/catppuccin-latte.css
@@ -1,4 +1,4 @@
-root: {
+:root: {
   --rosewater: #dc8a78;
   --flamingo: #dd7878;
   --pink: #ea76cb;

--- a/themes/catppuccin-latte.css
+++ b/themes/catppuccin-latte.css
@@ -1,4 +1,4 @@
-:root: {
+:root {
   --rosewater: #dc8a78;
   --flamingo: #dd7878;
   --pink: #ea76cb;

--- a/themes/catppuccin-macchiato.css
+++ b/themes/catppuccin-macchiato.css
@@ -1,4 +1,4 @@
-root: {
+:root: {
   --rosewater: #f4dbd6;
   --flamingo: #f0c6c6;
   --pink: #f5bde6;

--- a/themes/catppuccin-macchiato.css
+++ b/themes/catppuccin-macchiato.css
@@ -1,4 +1,4 @@
-:root: {
+:root {
   --rosewater: #f4dbd6;
   --flamingo: #f0c6c6;
   --pink: #f5bde6;

--- a/themes/catppuccin-macchiato.css
+++ b/themes/catppuccin-macchiato.css
@@ -1,22 +1,30 @@
-:root {
-  --base: #24273a;
-  --surface0: #363a4f;
-  --surface1: #494d64;
-  --surface2: #5b6078;
-  --overlay0: #6e738d;
-  --overlay1: #8087a2;
-  --overlay2: #939ab7;
-  --subtext0: #a5adcb;
-  --text: #cad3f5;
-  --yellow: #eed49f;
-  --peach: #f5a97f;
-  --red: #ed8796;
+root: {
+  --rosewater: #f4dbd6;
+  --flamingo: #f0c6c6;
   --pink: #f5bde6;
   --mauve: #c6a0f6;
-  --blue: #8aadf4;
-  --sky: #91d7e3;
+  --red: #ed8796;
+  --maroon: #ee99a0;
+  --peach: #f5a97f;
+  --yellow: #eed49f;
   --green: #a6da95;
-  --rosewater: #f4dbd6;
+  --teal: #8bd5ca;
+  --sky: #91d7e3;
+  --sapphire: #7dc4e4;
+  --blue: #8aadf4;
+  --lavender: #b7bdf8;
+  --text: #cad3f5;
+  --subtext1: #b8c0e0;
+  --subtext0: #a5adcb;
+  --overlay2: #939ab7;
+  --overlay1: #8087a2;
+  --overlay0: #6e738d;
+  --surface2: #5b6078;
+  --surface1: #494d64;
+  --surface0: #363a4f;
+  --base: #24273a;
+  --mantle: #1e2030;
+  --crust: #181926;
 }
 
 .logo a span {

--- a/themes/catppuccin-mocha.css
+++ b/themes/catppuccin-mocha.css
@@ -1,4 +1,4 @@
-:root: {
+:root {
   --rosewater: #f5e0dc;
   --flamingo: #f2cdcd;
   --pink: #f5c2e7;

--- a/themes/catppuccin-mocha.css
+++ b/themes/catppuccin-mocha.css
@@ -1,4 +1,4 @@
-root: {
+:root: {
   --rosewater: #f5e0dc;
   --flamingo: #f2cdcd;
   --pink: #f5c2e7;

--- a/themes/catppuccin-mocha.css
+++ b/themes/catppuccin-mocha.css
@@ -1,23 +1,30 @@
-:root {
-  --base: #eff1f5;
-  --surface0: #ccd0da;
-  --surface1: #bcc0cc;
-  --surface2: #acb0be;
-  --overlay0: #9ca0b0;
-  --overlay1: #8c8fa1;
-  --overlay2: #7c7f93;
-  --subtext0: #6c6f85;
-  --text: #4c4f69;
-  --yellow: #df8e1d;
-  --peach: #fe640b;
-  --red: #d20f39;
-  --lavender: #7287fd;
-  --pink: #ea76cb;
-  --mauve: #8839ef;
-  --blue: #1e66f5;
-  --sky: #04a5e5;
-  --green: #40a02b;
-  --rosewater: #dc8a78;
+root: {
+  --rosewater: #f5e0dc;
+  --flamingo: #f2cdcd;
+  --pink: #f5c2e7;
+  --mauve: #cba6f7;
+  --red: #f38ba8;
+  --maroon: #eba0ac;
+  --peach: #fab387;
+  --yellow: #f9e2af;
+  --green: #a6e3a1;
+  --teal: #94e2d5;
+  --sky: #89dceb;
+  --sapphire: #74c7ec;
+  --blue: #89b4fa;
+  --lavender: #b4befe;
+  --text: #cdd6f4;
+  --subtext1: #bac2de;
+  --subtext0: #a6adc8;
+  --overlay2: #9399b2;
+  --overlay1: #7f849c;
+  --overlay0: #6c7086;
+  --surface2: #585b70;
+  --surface1: #45475a;
+  --surface0: #313244;
+  --base: #1e1e2e;
+  --mantle: #181825;
+  --crust: #11111b;
 }
 
 .logo a span {


### PR DESCRIPTION
This PR allows the themes to be generated via our built-in templating tool [catppuccin/whiskers](https://github.com/catppuccin/whiskers). The general workflow is that the `miniflux.tera` file is edited, then running `whiskers miniflux.tera` will re-generate all the theme files.

@mark-pitblado Are you happy/comfortable making any further changes going forward using this tool? (Also are you still happy to continue being the maintainer? Thankfully it doesn't look like there are many breaking changes to the theming?)